### PR TITLE
add security-events: write permission for code scanning upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+  
 env:
   GO_VERSION: '1.24'
   NODE_VERSION: '18'


### PR DESCRIPTION
fix(ci): add security-events: write permission for code scanning upload

Summary:
- Added the required 'security-events: write' permission to the CI workflow to allow uploading SARIF/code scanning results from security scanning jobs.

Motivation:
- Fixes "Resource not accessible by integration" error during security scan uploads.
- Ensures security scanning results are properly reported in GitHub.

Type of Change:
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔧 Build/CI configuration changes

Testing:
- [x] Manual: Triggered CI, verified that security scan uploads no longer error.

Reviewers:
- @sukhera